### PR TITLE
Add modal to see portfolio images

### DIFF
--- a/src/components/pages/detail/ModalDetail.tsx
+++ b/src/components/pages/detail/ModalDetail.tsx
@@ -1,23 +1,127 @@
-import React from "react";
-import Modal from "@mui/joy/Modal";
-import ModalClose from "@mui/joy/ModalClose";
-import Sheet from "@mui/joy/Sheet";
+import React, { useEffect, useState } from 'react';
+import Modal from '@mui/joy/Modal';
+import ModalClose from '@mui/joy/ModalClose';
+import Sheet from '@mui/joy/Sheet';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel';
+import { MdNavigateBefore, MdNavigateNext } from 'react-icons/md';
 
-const ModalDetail = ({open, setOpen}) => {
+const ModalDetail = ({ open, setOpen, studio }) => {
+  const [currentPage, setCurrentPage] = React.useState(0);
+  const [api, setApi] = React.useState();
+
+  const totalPhotos = studio?.portfolioPhotos?.length || 0;
+
+  useEffect(() => {
+    if (!api) return;
+
+    api.on('select', () => {
+      setCurrentPage(api.selectedScrollSnap());
+    });
+
+    // Actualizar la posición del carrusel cuando cambia currentPage
+    api.scrollTo(currentPage);
+  }, [api, currentPage]);
+
+  const handlePrevious = () => {
+    if (currentPage > 0) {
+      setCurrentPage((prev) => prev - 1);
+    } else {
+      setCurrentPage(totalPhotos - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentPage < totalPhotos - 1) {
+      setCurrentPage((prev) => prev + 1);
+    } else {
+      setCurrentPage(0);
+    }
+  };
+
+  const handleImageClick = (index: number) => {
+    setCurrentPage(index);
+  };
+
   return (
     <Modal
       aria-labelledby="modal-title"
       aria-describedby="modal-desc"
       open={open}
       onClose={() => setOpen(false)}
-      sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
+      sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
     >
       <Sheet
         variant="outlined"
-        sx={{ width: 800, borderRadius: "md", p: 3, boxShadow: "lg" }}
+        sx={{
+          width: '100vw',
+          borderRadius: 'md',
+          p: 6,
+          boxShadow: 'lg',
+          height: '70svh',
+        }}
+        className="flex justify-center items-center h-max"
       >
         <ModalClose variant="plain" sx={{ m: 1 }} />
-        Hola
+
+        <div className="flex flex-col gap-10 h-[70svh] justify-center items-center">
+          <div className="w-4/9">
+            <img
+              src={studio.portfolioPhotos[currentPage]?.image}
+              alt="logo"
+              className="w-full h-full object-cover rounded-lg"
+            />
+          </div>
+
+          <div className="flex items-center justify-center gap-4">
+            <button
+              onClick={handlePrevious}
+              className=" bg-[#D05858] p-1 md:p-2 rounded-full shadow-lg hover:bg-white"
+            >
+              <MdNavigateBefore className="text-white size-8 hover:text-[#D05858]" />
+            </button>
+            <Carousel
+              className="w-[50%] h-full"
+              setApi={setApi}
+              opts={{
+                align: 'start',
+                loop: true,
+                skipSnaps: false,
+                dragFree: false,
+              }}
+            >
+              <CarouselContent>
+                {studio.portfolioPhotos.map((photo, index) => (
+                  <CarouselItem
+                    key={index}
+                    className="basis-1/5 cursor-pointer h-min max-sm:basis-1/2"
+                    onClick={() => handleImageClick(index)}
+                  >
+                    <img
+                      src={photo.image}
+                      alt={`Imagen ${index + 1}`}
+                      className="object-cover rounded-lg transition-opacity duration-300 h-max"
+                      style={{
+                        aspectRatio: '1/1',
+                        opacity: index === currentPage ? 1 : 0.7,
+                      }}
+                      draggable={false}
+                    />
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+            </Carousel>
+            <button
+              onClick={handleNext}
+              className=" bg-[#D05858] p-1 md:p-2 rounded-full shadow-lg hover:bg-white"
+            >
+              <MdNavigateNext className="text-white size-8 hover:text-[#D05858]" />
+            </button>
+          </div>
+        </div>
       </Sheet>
     </Modal>
   );

--- a/src/components/pages/home/recommendations/CardRecommend.tsx
+++ b/src/components/pages/home/recommendations/CardRecommend.tsx
@@ -24,7 +24,7 @@ export default function CardRecommend({ studio }: { studio: Studio }) {
           sx={{ width: 70, height: 70 }}
         />
         <h3 className="text-sm text-black truncate">{studio.studioName}</h3>
-        <p className="text-lg text-black font-bold truncate">
+        <p className="text-lg text-black font-bold break-words overflow-hidden line-clamp-2 text-center">
           {studio.studioSpecialties[0].specialty.specialtyName}
         </p>
         <p className="text-sm text-gray-500 text-center">

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -46,7 +46,7 @@ const Detail = () => {
             />
             <div className="flex flex-col justify-center text-black space-y-2.5 font-semibold">
               <h1 className="text-4xl md:text-6xl">{studio.studioName}</h1>
-              <h2 className="text-[#D05858] text-4xl">
+              <h2 className="text-[#D05858] text-4xl ">
                 {studio.studioSpecialties[0].specialty.specialtyName}
               </h2>
             </div>
@@ -158,7 +158,7 @@ const Detail = () => {
             </div>
           </div>
         </section>
-        <ModalDetail open={open} setOpen={setOpen} />
+        <ModalDetail open={open} setOpen={setOpen} studio={studio} />
       </div>
     </main>
   );

--- a/src/pages/home/RecommendSection.tsx
+++ b/src/pages/home/RecommendSection.tsx
@@ -1,8 +1,5 @@
 import CardRecommend from '@/components/pages/home/recommendations/CardRecommend';
 import { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { fetchStudios } from '../../reducers/studioSlice';
-import { Studio } from '@/types';
 import useRandomStudios from '@/hooks/useRandomStudios';
 
 const RecommendSection = () => {
@@ -10,14 +7,23 @@ const RecommendSection = () => {
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const { data: studios, status, error } = useRandomStudios();
 
-  if (status === 'loading') return <p>Cargando estudios...</p>;
-  if (status === 'failed') return <p>Error: {error}</p>;
-
   const getItemsPerPage = () => {
     if (windowWidth >= 1024) return 6;
     if (windowWidth >= 768) return 4;
     return 2;
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  if (status === 'loading') return <p>Cargando estudios...</p>;
+  if (status === 'failed') return <p>Error: {error}</p>;
 
   const itemsPerPage = getItemsPerPage();
   const totalPages = Math.ceil(studios.length / itemsPerPage);


### PR DESCRIPTION
This pull request includes several changes across multiple files to enhance the functionality and user experience of the `ModalDetail` component and improve the layout of the `CardRecommend` component. The most important changes include adding a carousel to the `ModalDetail` component, updating the `CardRecommend` component to handle text overflow better, and ensuring the `ModalDetail` component receives the necessary `studio` prop.

### Enhancements to `ModalDetail` component:

* Added carousel functionality to display studio portfolio photos, including navigation buttons and image click handling in `src/components/pages/detail/ModalDetail.tsx`.
* Updated the `Detail` page to pass the `studio` prop to the `ModalDetail` component in `src/pages/Detail.tsx`.

### Improvements to `CardRecommend` component:

* Modified the `CardRecommend` component to handle text overflow better by using `break-words` and `line-clamp-2` classes in `src/components/pages/home/recommendations/CardRecommend.tsx`.

### Other updates:

* Refactored the `RecommendSection` component to include a resize event listener for responsive design in `src/pages/home/RecommendSection.tsx`.