### PR TITLE
add: vercel config to enable reload on all paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request includes a change to the `vercel.json` file to configure URL rewrites. The change ensures that all routes are redirected to `index.html`.

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R1-R8): Added a rewrite rule to redirect all routes to `index.html`.