### PR TITLE
add: 404 page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import {BrowserRouter as Router, Route, Routes} from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Layout from "./components/Layout";
 import Home from "./pages/Home";
 import Detail from "./pages/Detail";
@@ -11,10 +11,11 @@ import HomeFeatures from "./pages/admin/feature/Home";
 import AddFeature from "./pages/admin/feature/AddFeature";
 import UsersHome from "./pages/admin/user/UsersTable";
 import HomeSpecialies from "./pages/admin/specialy/Home";
-import PrivateRoute, {PrivateRouteAuth} from "./components/PrivateRoute";
+import PrivateRoute, { PrivateRouteAuth } from "./components/PrivateRoute";
 import Favorites from "./pages/Favorites";
 import ConfirmQuote from "./pages/ConfirmQuote";
 import Bookings from "@/pages/Bookings";
+import NotFound from "@/components/pages/NotFound";
 
 function App() {
   return (
@@ -22,17 +23,17 @@ function App() {
       <Layout>
         <Routes>
           {/* Rutas públicas */}
-          <Route path="/" element={<Home/>}/>
-          <Route path="/register" element={<Register/>}/>
-          <Route path="/login" element={<Login/>}/>
-          <Route path="/studio/:id" element={<Detail/>}/>
+          <Route path="/" element={<Home />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/studio/:id" element={<Detail />} />
 
           {/* Ruta visibles despues del login */}
           <Route
             path="/favorites"
             element={
               <PrivateRouteAuth>
-                <Favorites/>
+                <Favorites />
               </PrivateRouteAuth>
             }
           />
@@ -40,7 +41,7 @@ function App() {
             path="/bookings"
             element={
               <PrivateRouteAuth>
-                <Bookings/>
+                <Bookings />
               </PrivateRouteAuth>
             }
           />
@@ -48,7 +49,7 @@ function App() {
             path="/confirm-quote"
             element={
               <PrivateRouteAuth>
-                <ConfirmQuote/>
+                <ConfirmQuote />
               </PrivateRouteAuth>
             }
           />
@@ -58,7 +59,7 @@ function App() {
             path="/administration"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <AdminHome/>
+                <AdminHome />
               </PrivateRoute>
             }
           />
@@ -66,7 +67,7 @@ function App() {
             path="/administration/create_studio"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <AddStudio/>
+                <AddStudio />
               </PrivateRoute>
             }
           />
@@ -74,7 +75,7 @@ function App() {
             path="/administration/edit_studio/:id"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <EditStudio/>
+                <EditStudio />
               </PrivateRoute>
             }
           />
@@ -82,7 +83,7 @@ function App() {
             path="/administration/users"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <UsersHome/>
+                <UsersHome />
               </PrivateRoute>
             }
           />
@@ -91,7 +92,7 @@ function App() {
             path="/administration/features"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <HomeFeatures/>
+                <HomeFeatures />
               </PrivateRoute>
             }
           />
@@ -100,7 +101,7 @@ function App() {
             path="/administration/create_feature"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <AddFeature/>
+                <AddFeature />
               </PrivateRoute>
             }
           />
@@ -109,10 +110,12 @@ function App() {
             path="/administration/specialties"
             element={
               <PrivateRoute role="ROLE_ADMINISTRATOR">
-                <HomeSpecialies/>
+                <HomeSpecialies />
               </PrivateRoute>
             }
           />
+
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/components/pages/NotFound.tsx
+++ b/src/components/pages/NotFound.tsx
@@ -1,0 +1,23 @@
+const NotFound = () => {
+  return (
+    <div className="min-h-[90svh] flex flex-col items-center justify-center bg-gray-100">
+      <div className="text-center p-8 bg-white rounded-lg shadow-lg">
+        <h1 className="text-6xl font-bold text-[#D05858] mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-gray-800 mb-4">
+          Página no encontrada
+        </h2>
+        <p className="text-gray-600 mb-8">
+          Lo sentimos, la página que estás buscando no existe.
+        </p>
+        <a
+          href="/"
+          className="px-6 py-3 bg-[#D05858] text-white rounded-lg hover:bg-[#b94444] transition-colors"
+        >
+          Volver al inicio
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,12 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "routes": [
+    {
+      "src": "/[^.]+",
+      "dest": "/",
+      "status": 200
+    }
   ]
 }


### PR DESCRIPTION
This pull request introduces a new `NotFound` page to handle 404 errors and updates routing to ensure users are directed to this page when they navigate to an undefined route. The most important changes include importing and using the new `NotFound` component, defining the `NotFound` component itself, and updating the Vercel configuration to handle 404s correctly.

Routing updates:

* [`src/App.jsx`](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R18): Imported the `NotFound` component and added a new route to display the `NotFound` page for any undefined paths. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R18) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R117-R118)

New `NotFound` component:

* [`src/components/pages/NotFound.tsx`](diffhunk://#diff-ed01496f85480d73b0c432af36774926a1303bf92350c3b87334503c3cb01bacR1-R23): Created a new `NotFound` component that displays a 404 error message and a link to return to the homepage.

Vercel configuration:

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240R7-R13): Updated the Vercel configuration to redirect all non-file routes to the index page, ensuring the React router can handle 404s.